### PR TITLE
Fix broken image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,4 @@ Paste text into the entry and hit start to generate a word cloud that
 is saved to the Sugar Journal.
 
 Based on the pytagcloud package.
-
-![alt text](http://github.com/walterbender/wordcloud/blob/master/WordCloud.png?raw=true "Word Cloud Example")
+![Word Cloud](WordCloud.png)


### PR DESCRIPTION
The word cloud example in the README.md is not shown.  At the moment
it looks like this;

![alt text]
(http://github.com/walterbender/wordcloud/blob/master/WordCloud.png
?raw=true "Word Cloud Example")

This was done by Walter Bender in 2014 as part of commit
d04deeb866adb266dca3c33e63a2a00e8d01e43c, when the repository was in
his account on GitHub.  It was the wrong way to do it because the link
is not relative.  The link was absolute.  Since then the repository
moved to sugarlabs, which is why the image is not shown.

Co-authored-by: James Cameron <quozl@laptop.org>
undo related change, make link relative, rewrite commit message

Replaces: https://github.com/sugarlabs/wordcloud/pull/7